### PR TITLE
Fix for AutofitHeight

### DIFF
--- a/library/src/main/java/me/grantland/widget/AutofitHelper.java
+++ b/library/src/main/java/me/grantland/widget/AutofitHelper.java
@@ -137,6 +137,7 @@ public class AutofitHelper {
         if (isAutofitHeightEnabled) {
             int targetHeight = view.getHeight() - view.getPaddingTop() - view.getPaddingBottom();
             if (targetHeight > 0) {
+                paint.setTextSize(size);
                 float textHeight = getTextHeight(text, paint, targetWidth, size);
                 float heightRatio = targetHeight / textHeight;
                 float newSize = size * heightRatio;


### PR DESCRIPTION
The autoheight part didn't take in account the actual size calculated a few lines before, then getTextHeight in some cases was giving wrong results